### PR TITLE
Calculate missing scores

### DIFF
--- a/src/tank_risk_tool.pyt
+++ b/src/tank_risk_tool.pyt
@@ -265,7 +265,7 @@ class TankResult():
 
         elif layer_name == 'soil':
             texture = row[1]
-            value = texture
+            value = texture.casefold()
 
             if value.contains('gravel'):
                 score = 5
@@ -277,6 +277,8 @@ class TankResult():
                 score = 5
             elif value.contains('bould'):
                 score = 5
+            elif value.contains('course'):
+                score = 5
             elif len(value.strip()) == 0:
                 score = 5
             elif value.contains('sand'):
@@ -287,8 +289,12 @@ class TankResult():
                 score = 3
             elif value.contains('varia'):
                 score = 3
-            elif value == 'loam' :
+            elif value == 'loam':
                 score = 3
+            elif value.contains('ashy'):
+                score = 3
+            elif value.contains('shaly'):
+                score = 2
             elif value.contains('silt'):
                 score = 2
             elif value.contains('plant'):

--- a/src/tank_risk_tool.pyt
+++ b/src/tank_risk_tool.pyt
@@ -267,6 +267,41 @@ class TankResult():
             texture = row[1]
             value = texture
 
+            if value.contains('gravel'):
+                score = 5
+            elif value.contains('cobb'):
+                score = 5
+            elif value.contains('ston'):
+                score = 5
+            elif value.contains('frag'):
+                score = 5
+            elif value.contains('bould'):
+                score = 5
+            elif len(value.strip()) == 0:
+                score = 5
+            elif value.contains('sand'):
+                score = 4
+            elif value.contains('flag'):
+                score = 3
+            elif value.contains('channer'):
+                score = 3
+            elif value.contains('varia'):
+                score = 3
+            elif value == 'loam' :
+                score = 3
+            elif value.contains('silt'):
+                score = 2
+            elif value.contains('plant'):
+                score = 2
+            elif value.contains('pea'):
+                score = 2
+            elif value.contains('clay'):
+                score = 1
+            elif value.contains('bedr'):
+                score = 1
+            else:
+                score = 1000
+
             tank.set_value_for_layer(layer_name, value)
             tank.set_severity_for_layer(layer_name, score)
 

--- a/src/tank_risk_tool.pyt
+++ b/src/tank_risk_tool.pyt
@@ -309,6 +309,15 @@ class TankResult():
             depth = row[1]
             value = depth
 
+            if value == 0:
+                score = 5
+            elif value == 10:
+                score = 2.5
+            elif value == 30:
+                score = 1
+            else:
+                score = 0
+
             tank.set_value_for_layer(layer_name, value)
             tank.set_severity_for_layer(layer_name, score)
 


### PR DESCRIPTION
This uses the data supplied in #29 to add scores for these two layers. With your approval I'll merge and create a new release. If you want to address the missing soil types, now is the time to assign them a score.

cc @rsaathoff

closes #29